### PR TITLE
Fix ChampTLDR selected role out of bounds bug

### DIFF
--- a/src/pages/champion/[championName].js
+++ b/src/pages/champion/[championName].js
@@ -165,6 +165,10 @@ export function ChampionDetails({ championName, champDetails, champInfo, champSt
             return;
         }
 
+        // Reset some state when searching for a champ from the same page
+        setSelectedChampTldr(0)
+        setViewingAbility(0)
+
         // Get recent stats diff
         const sortedStats = [...champStat.positionRanks].sort((a, b) => DateTime.fromISO(b.updateDate) - DateTime.fromISO(a.updateDate))
         const statDates = []


### PR DESCRIPTION
The role selected index doesn't reset when you search a champion on the champion page, so when you have >0 index role selected and search another champion with only 1 role, it'll crash because the TLDR state is still 1, which is out of bounds of the new array.